### PR TITLE
Frontend: State Transitions & Assignment Interface

### DIFF
--- a/frontend/app/data.py
+++ b/frontend/app/data.py
@@ -304,10 +304,15 @@ def transition_incident(
             "actor": actor,
         })
 
-    if new_assignee is not None and new_assignee != incident.get("assigned_to"):
+    if new_assignee and new_assignee != incident.get("assigned_to"):
         old_assignee = incident.get("assigned_to") or "Unassigned"
-        new_assignee_display = new_assignee if new_assignee else "Unassigned"
-        incident["assigned_to"] = new_assignee
+        if new_assignee == "Unassigned":
+            new_assignee_value = None
+            new_assignee_display = "Unassigned"
+        else:
+            new_assignee_value = new_assignee
+            new_assignee_display = new_assignee
+        incident["assigned_to"] = new_assignee_value
         incident.setdefault("timeline", []).append({
             "type": "assignment",
             "message": f"Assigned from {old_assignee} to {new_assignee_display}",

--- a/frontend/app/data.py
+++ b/frontend/app/data.py
@@ -8,6 +8,17 @@ import streamlit as st
 SEVERITIES = ["low", "medium", "high", "critical"]
 STATES = ["open", "triaged", "assigned", "in_progress", "resolved", "closed"]
 
+STATE_TRANSITIONS = {
+    "open": ["triaged"],
+    "triaged": ["assigned"],
+    "assigned": ["in_progress"],
+    "in_progress": ["resolved"],
+    "resolved": ["closed", "triaged"],
+    "closed": [],
+}
+
+USERS = ["Marco", "Nina", "Carlos", "Irene", "Laura", "Felipe", "Sara", "Andre"]
+
 
 def _timeline_entry(
     entry_type: str,
@@ -224,3 +235,84 @@ def _get_assignee_options(incidents: Iterable[dict]) -> list[str]:
 @st.cache_data
 def get_assignee_options(_incidents: list[dict]) -> list[str]:
     return _get_assignee_options(_incidents)
+
+
+def get_available_transitions(current_state: str) -> list[str]:
+    return STATE_TRANSITIONS.get(current_state, [])
+
+
+def can_transition(current_state: str, target_state: str) -> bool:
+    return target_state in STATE_TRANSITIONS.get(current_state, [])
+
+
+def validate_transition(incident: dict, target_state: str, resolution_summary: str = None) -> tuple[bool, str]:
+    current_state = incident["state"]
+    severity = incident["severity"]
+    assignee = incident.get("assigned_to")
+
+    if target_state == "closed" and severity == "critical" and not resolution_summary:
+        return False, "Cannot close CRITICAL incident without resolution summary."
+
+    if target_state == "in_progress" and not assignee:
+        return False, "Cannot move to IN_PROGRESS without assignee."
+
+    valid_transitions = STATE_TRANSITIONS.get(current_state, [])
+    if target_state not in valid_transitions:
+        return False, f"Invalid transition from {current_state} to {target_state}."
+
+    return True, ""
+
+
+def transition_incident(
+    incident: dict,
+    target_state: str,
+    actor: str,
+    resolution_summary: str = None,
+    new_severity: str = None,
+    new_assignee: str = None,
+) -> tuple[bool, str]:
+    valid, error = validate_transition(incident, target_state, resolution_summary)
+    if not valid:
+        return False, error
+
+    timestamp = datetime.now(timezone.utc)
+    current_state = incident["state"]
+
+    if target_state != current_state:
+        incident["state"] = target_state
+        incident.setdefault("timeline", []).append({
+            "type": "state",
+            "message": f"State changed from {current_state} to {target_state}",
+            "timestamp": timestamp,
+            "actor": actor,
+        })
+        if resolution_summary:
+            incident.setdefault("timeline", []).append({
+                "type": "resolution",
+                "message": f"Resolution: {resolution_summary}",
+                "timestamp": timestamp,
+                "actor": actor,
+            })
+
+    if new_severity and new_severity != incident.get("severity"):
+        old_severity = incident.get("severity")
+        incident["severity"] = new_severity
+        incident.setdefault("timeline", []).append({
+            "type": "severity",
+            "message": f"Severity changed from {old_severity} to {new_severity}",
+            "timestamp": timestamp,
+            "actor": actor,
+        })
+
+    if new_assignee is not None and new_assignee != incident.get("assigned_to"):
+        old_assignee = incident.get("assigned_to") or "Unassigned"
+        new_assignee_display = new_assignee if new_assignee else "Unassigned"
+        incident["assigned_to"] = new_assignee
+        incident.setdefault("timeline", []).append({
+            "type": "assignment",
+            "message": f"Assigned from {old_assignee} to {new_assignee_display}",
+            "timestamp": timestamp,
+            "actor": actor,
+        })
+
+    return True, "Transition applied successfully."

--- a/frontend/app/pages/incident_detail.py
+++ b/frontend/app/pages/incident_detail.py
@@ -90,7 +90,7 @@ if can_edit:
             st.caption("No transitions available")
 
     with trans_col2:
-        user_options = [""] + USERS
+        user_options = ["Unassigned"] + USERS
         new_assignee = st.selectbox(
             "Assign to",
             user_options,
@@ -114,7 +114,7 @@ if can_edit:
 
     if apply_transition:
         target_state = new_state if new_state else None
-        assignee_value = new_assignee if new_assignee else None
+        assignee_value = new_assignee if new_assignee and new_assignee != "Unassigned" else None
         severity_value = new_severity if new_severity else None
 
         if target_state or assignee_value or (severity_value and severity_value != selected_incident["severity"]):

--- a/frontend/app/pages/incident_detail.py
+++ b/frontend/app/pages/incident_detail.py
@@ -4,7 +4,13 @@ from datetime import datetime, timezone
 
 import streamlit as st
 
-from data import get_incidents
+from data import (
+    SEVERITIES,
+    USERS,
+    get_available_transitions,
+    get_incidents,
+    transition_incident,
+)
 
 
 st.set_page_config(page_title="Incident Detail", layout="wide")
@@ -31,18 +37,28 @@ if selected_incident is None:
     incident_id = st.selectbox("Select an incident", [incident["id"] for incident in incidents])
     selected_incident = incident_map[incident_id]
 
+current_role = st.session_state.get("active_role", "Operator")
+can_edit = current_role in ("Commander", "Admin")
+
 st.subheader(selected_incident["title"])
 
 st.write(selected_incident["description"])
 
-st.write(
-    {
-        "Severity": selected_incident["severity"],
-        "State": selected_incident["state"],
-        "Creator": selected_incident["creator"],
-        "Assignee": selected_incident["assigned_to"] or "Unassigned",
-    }
-)
+col1, col2 = st.columns(2)
+with col1:
+    st.write(
+        {
+            "Severity": selected_incident["severity"],
+            "State": selected_incident["state"],
+            "Creator": selected_incident["creator"],
+        }
+    )
+with col2:
+    st.write(
+        {
+            "Assignee": selected_incident["assigned_to"] or "Unassigned",
+        }
+    )
 
 created_at = selected_incident["created_at"].astimezone(timezone.utc)
 created_at_text = created_at.strftime("%Y-%m-%d %H:%M UTC")
@@ -51,8 +67,74 @@ st.caption(f"Created at {created_at_text}")
 
 link_value = f"incident_detail?incident_id={selected_incident['id']}"
 st.text_input("Shareable link", value=link_value, disabled=True)
-if st.button("Copy link"):
+if st.button("Copy link", key="copy_link"):
     st.info("Copy the link from the field above.")
+
+if can_edit:
+    st.divider()
+    st.subheader("Control Panel")
+
+    available_transitions = get_available_transitions(selected_incident["state"])
+
+    trans_col1, trans_col2, trans_col3 = st.columns([2, 2, 1])
+
+    with trans_col1:
+        if available_transitions:
+            new_state = st.selectbox(
+                "Transition to",
+                [""] + available_transitions,
+                index=0,
+            )
+        else:
+            new_state = ""
+            st.caption("No transitions available")
+
+    with trans_col2:
+        user_options = [""] + USERS
+        new_assignee = st.selectbox(
+            "Assign to",
+            user_options,
+            index=0,
+        )
+
+    with trans_col3:
+        severity_options = [""] + SEVERITIES
+        current_severity_idx = SEVERITIES.index(selected_incident["severity"]) + 1
+        new_severity = st.selectbox(
+            "Severity",
+            severity_options,
+            index=current_severity_idx,
+        )
+
+    resolution_summary = ""
+    if new_state == "closed" and selected_incident["severity"] == "critical":
+        resolution_summary = st.text_input("Resolution summary (required for CRITICAL)")
+
+    apply_transition = st.button("Apply Changes")
+
+    if apply_transition:
+        target_state = new_state if new_state else None
+        assignee_value = new_assignee if new_assignee else None
+        severity_value = new_severity if new_severity else None
+
+        if target_state or assignee_value or (severity_value and severity_value != selected_incident["severity"]):
+            success, message = transition_incident(
+                selected_incident,
+                target_state,
+                current_role,
+                resolution_summary if target_state == "closed" else None,
+                severity_value if severity_value and severity_value != selected_incident["severity"] else None,
+                assignee_value if assignee_value else None,
+            )
+            if success:
+                st.success(message)
+                st.rerun()
+            else:
+                st.error(message)
+        else:
+            st.warning("No changes to apply.")
+
+st.divider()
 
 st.subheader("Timeline")
 


### PR DESCRIPTION
## Summary
Closes #15

## Changes
- Add state machine transitions and validation rules in data.py
- Add control panel for Commander/Admin to:
  - Transition incident state (respects state machine)
  - Assign users via dropdown
  - Change severity with confirmation
- Validation rules:
  - Cannot close CRITICAL incident without resolution summary
  - Cannot move to IN_PROGRESS without assignee
  - Invalid transitions show error message
- Timeline auditing for all changes (who, when, what changed)
- Role-based visibility (Commander/Admin see control panel, Operator/Manager are read-only)