### PR TITLE
Frontend: Admin Panel & Dashboard Views

### DIFF
--- a/frontend/app/data.py
+++ b/frontend/app/data.py
@@ -8,6 +8,17 @@ import streamlit as st
 SEVERITIES = ["low", "medium", "high", "critical"]
 STATES = ["open", "triaged", "assigned", "in_progress", "resolved", "closed"]
 
+STATE_TRANSITIONS = {
+    "open": ["triaged"],
+    "triaged": ["assigned"],
+    "assigned": ["in_progress"],
+    "in_progress": ["resolved"],
+    "resolved": ["closed", "triaged"],
+    "closed": [],
+}
+
+USERS = ["Marco", "Nina", "Carlos", "Irene", "Laura", "Felipe", "Sara", "Andre"]
+
 
 def _timeline_entry(
     entry_type: str,
@@ -224,3 +235,75 @@ def _get_assignee_options(incidents: Iterable[dict]) -> list[str]:
 @st.cache_data
 def get_assignee_options(_incidents: list[dict]) -> list[str]:
     return _get_assignee_options(_incidents)
+
+
+def get_counts_by_severity(incidents: list[dict]) -> dict[str, int]:
+    counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+    for incident in incidents:
+        severity = incident.get("severity", "low")
+        if severity in counts:
+            counts[severity] += 1
+    return counts
+
+
+def get_counts_by_state(incidents: list[dict]) -> dict[str, int]:
+    counts = {}
+    for state in STATES:
+        counts[state] = 0
+    for incident in incidents:
+        state = incident.get("state")
+        if state in counts:
+            counts[state] += 1
+    return counts
+
+
+def get_critical_recent(incidents: list[dict], hours: int = 24) -> list[dict]:
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
+    recent = []
+    for incident in incidents:
+        if incident.get("severity") == "critical":
+            created = incident.get("created_at")
+            if created and created > cutoff:
+                recent.append(incident)
+    return recent
+
+
+def get_unassigned(incidents: list[dict]) -> list[dict]:
+    return [i for i in incidents if not i.get("assigned_to")]
+
+
+def get_incidents_by_day(incidents: list[dict], days: int = 7) -> dict[str, int]:
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    by_day = {}
+    for i in range(days):
+        day = (datetime.now(timezone.utc) - timedelta(days=i)).strftime("%Y-%m-%d")
+        by_day[day] = 0
+    for incident in incidents:
+        created = incident.get("created_at")
+        if created and created > cutoff:
+            day = created.strftime("%Y-%m-%d")
+            if day in by_day:
+                by_day[day] += 1
+    return by_day
+
+
+def get_audit_logs(incidents: list[dict], actor_filter: str = None, type_filter: str = None) -> list[dict]:
+    logs = []
+    for incident in incidents:
+        timeline = incident.get("timeline", [])
+        for entry in timeline:
+            if entry.get("type") in ("state", "severity", "assignment"):
+                if actor_filter and entry.get("actor") != actor_filter:
+                    continue
+                if type_filter and entry.get("type") != type_filter:
+                    continue
+                logs.append({
+                    "incident_id": incident["id"],
+                    "incident_title": incident["title"],
+                    "type": entry.get("type"),
+                    "message": entry.get("message"),
+                    "actor": entry.get("actor"),
+                    "timestamp": entry.get("timestamp"),
+                })
+    logs.sort(key=lambda x: x.get("timestamp", datetime.min), reverse=True)
+    return logs

--- a/frontend/app/main.py
+++ b/frontend/app/main.py
@@ -31,6 +31,13 @@ st.title("IncidentFlow")
 
 st.page_link("pages/create_incident.py", label="Create incident")
 
+current_role = st.session_state.get("active_role", "Operator")
+if current_role in ("Manager", "Admin"):
+    st.page_link("pages/manager_dashboard.py", label="Dashboard")
+
+if current_role == "Admin":
+    st.page_link("pages/admin_dashboard.py", label="Admin Panel")
+
 if "incidents" not in st.session_state:
     st.session_state["incidents"] = get_incidents()
 

--- a/frontend/app/pages/admin_dashboard.py
+++ b/frontend/app/pages/admin_dashboard.py
@@ -34,12 +34,25 @@ if not is_manager:
     st.page_link("main.py", label="Back to list")
     st.stop()
 
-auto_refresh = st.checkbox("Auto-refresh (30s)", value=True)
+
+def render_auto_refresh(interval_seconds: int = 30):
+    st.markdown(
+        f"""
+        <meta http-equiv="refresh" content="{interval_seconds}">
+        <script>
+            setTimeout(function(){{
+                window.location.reload();
+            }}, {interval_seconds * 1000});
+        </script>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+auto_refresh = st.checkbox("Auto-refresh (30s)", value=False, key="admin_refresh")
 
 if auto_refresh:
-    import time
-    time.sleep(30)
-    st.rerun()
+    render_auto_refresh(30)
 
 st.header("Overview")
 
@@ -92,21 +105,24 @@ if is_admin:
             incident_map = {i["id"]: i for i in incidents}
             selected_incident = incident_map.get(assign_incident_id)
             if selected_incident:
-                new_assignee = st.selectbox("Assign to", USERS)
-                if st.button("Assign", key="reassign_btn"):
-                    success, msg = transition_incident(
-                        selected_incident,
-                        None,
-                        "Admin",
-                        None,
-                        None,
-                        new_assignee,
-                    )
-                    if success:
-                        st.success(msg)
-                        st.rerun()
-                    else:
-                        st.error(msg)
+                with st.form("reassign_form"):
+                    new_assignee = st.selectbox("Assign to", USERS)
+                    submitted = st.form_submit_button("Assign")
+                    
+                    if submitted:
+                        success, msg = transition_incident(
+                            selected_incident,
+                            "assigned",
+                            "Admin",
+                            None,
+                            None,
+                            new_assignee,
+                        )
+                        if success:
+                            st.success(msg)
+                            st.rerun()
+                        else:
+                            st.error(msg)
         else:
             st.info("No unassigned incidents")
 

--- a/frontend/app/pages/admin_dashboard.py
+++ b/frontend/app/pages/admin_dashboard.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import streamlit as st
+
+from data import (
+    SEVERITIES,
+    STATES,
+    USERS,
+    get_assignee_options,
+    get_audit_logs,
+    get_counts_by_severity,
+    get_counts_by_state,
+    get_critical_recent,
+    get_incidents_by_day,
+    get_incidents,
+    get_unassigned,
+    transition_incident,
+)
+
+
+st.set_page_config(page_title="Admin Dashboard", layout="wide")
+
+st.title("Admin Dashboard")
+
+if "incidents" not in st.session_state:
+    st.session_state["incidents"] = get_incidents()
+
+incidents = st.session_state["incidents"]
+
+current_role = st.session_state.get("active_role", "Operator")
+is_admin = current_role == "Admin"
+is_manager = current_role in ("Manager", "Admin")
+
+if not is_manager:
+    st.error("Access denied. Manager or Admin role required.")
+    st.page_link("main.py", label="Back to list")
+    st.stop()
+
+auto_refresh = st.checkbox("Auto-refresh (30s)", value=True)
+
+if auto_refresh:
+    import time
+    time.sleep(30)
+
+st.header("Overview")
+
+severity_counts = get_counts_by_severity(incidents)
+state_counts = get_counts_by_state(incidents)
+
+col1, col2, col3, col4 = st.columns(4)
+with col1:
+    st.metric("Critical", severity_counts.get("critical", 0))
+with col2:
+    st.metric("High", severity_counts.get("high", 0))
+with col3:
+    st.metric("Medium", severity_counts.get("medium", 0))
+with col4:
+    st.metric("Low", severity_counts.get("low", 0))
+
+st.header("State Distribution")
+for state, count in state_counts.items():
+    st.caption(f"{state}: {count}")
+
+st.header("Critical Recent (24h)")
+critical_recent = get_critical_recent(incidents, 24)
+if critical_recent:
+    for inc in critical_recent:
+        st.write(f"- {inc['id']}: {inc['title']} ({inc['state']})")
+else:
+    st.info("No critical incidents in last 24 hours")
+
+st.header("Unassigned Incidents")
+unassigned = get_unassigned(incidents)
+st.write(f"Total unassigned: {len(unassigned)}")
+
+for inc in unassigned[:5]:
+    st.write(f"- {inc['id']}: {inc['title']}")
+
+if is_admin:
+    st.divider()
+    st.header("Admin Panel")
+
+    tab1, tab2, tab3 = st.tabs(["Reassign", "Manage Users", "Audit Log"])
+
+    with tab1:
+        st.subheader("Reassign Incidents")
+        unassign = get_unassigned(incidents)
+        if unassign:
+            assign_incident_id = st.selectbox(
+                "Select incident",
+                [i["id"] for i in unassign],
+            )
+            incident_map = {i["id"]: i for i in incidents}
+            selected_incident = incident_map.get(assign_incident_id)
+            if selected_incident:
+                new_assignee = st.selectbox("Assign to", USERS)
+                if st.button("Assign", key="reassign_btn"):
+                    success, msg = transition_incident(
+                        selected_incident,
+                        None,
+                        "Admin",
+                        None,
+                        None,
+                        new_assignee,
+                    )
+                    if success:
+                        st.success(msg)
+                        st.rerun()
+                    else:
+                        st.error(msg)
+        else:
+            st.info("No unassigned incidents")
+
+    with tab2:
+        st.subheader("Manage Users")
+        st.write("Available users:", ", ".join(USERS))
+        st.info("User management Coming Soon")
+
+    with tab3:
+        st.subheader("Audit Log")
+        log_actor = st.selectbox("Filter by actor", [""] + USERS)
+        log_type = st.selectbox("Filter by type", ["", "state", "severity", "assignment"])
+
+        logs = get_audit_logs(
+            incidents,
+            actor_filter=log_actor if log_actor else None,
+            type_filter=log_type if log_type else None,
+        )
+
+        st.write(f"Total entries: {len(logs)}")
+        for log in logs[:20]:
+            ts = log.get("timestamp")
+            ts_str = ts.strftime("%Y-%m-%d %H:%M") if ts else "N/A"
+            st.write(f"- [{ts_str}] {log.get('type')}: {log.get('message')} (by {log.get('actor')})")
+
+st.page_link("main.py", label="Back to list")

--- a/frontend/app/pages/admin_dashboard.py
+++ b/frontend/app/pages/admin_dashboard.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
-
 import streamlit as st
 
 from data import (
-    SEVERITIES,
     STATES,
     USERS,
-    get_assignee_options,
     get_audit_logs,
     get_counts_by_severity,
     get_counts_by_state,
@@ -43,6 +39,7 @@ auto_refresh = st.checkbox("Auto-refresh (30s)", value=True)
 if auto_refresh:
     import time
     time.sleep(30)
+    st.rerun()
 
 st.header("Overview")
 

--- a/frontend/app/pages/manager_dashboard.py
+++ b/frontend/app/pages/manager_dashboard.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import streamlit as st
+
+from data import (
+    get_counts_by_severity,
+    get_counts_by_state,
+    get_critical_recent,
+    get_incidents_by_day,
+    get_incidents,
+    get_unassigned,
+)
+
+
+st.set_page_config(page_title="Manager Dashboard", layout="wide")
+
+st.title("Manager Dashboard")
+
+if "incidents" not in st.session_state:
+    st.session_state["incidents"] = get_incidents()
+
+incidents = st.session_state["incidents"]
+
+current_role = st.session_state.get("active_role", "Operator")
+is_manager = current_role in ("Manager", "Admin")
+
+if not is_manager:
+    st.error("Access denied. Manager or Admin role required.")
+    st.page_link("main.py", label="Back to list")
+    st.stop()
+
+auto_refresh = st.checkbox("Auto-refresh (30s)", value=False)
+
+if auto_refresh:
+    import time
+    time.sleep(30)
+
+st.header("Metrics")
+
+severity_counts = get_counts_by_severity(incidents)
+state_counts = get_counts_by_state(incidents)
+
+col1, col2, col3, col4 = st.columns(4)
+with col1:
+    st.metric("Critical", severity_counts.get("critical", 0))
+with col2:
+    st.metric("High", severity_counts.get("high", 0))
+with col3:
+    st.metric("Medium", severity_counts.get("medium", 0))
+with col4:
+    st.metric("Low", severity_counts.get("low", 0))
+
+st.header("State Distribution")
+state_cols = st.columns(len(STATES))
+for idx, state in enumerate(STATES):
+    with state_cols[idx]:
+        st.metric(state.title().replace("_", " "), state_counts.get(state, 0))
+
+st.header("Critical Recent (24h)")
+critical_recent = get_critical_recent(incidents, 24)
+if critical_recent:
+    for inc in critical_recent:
+        with st.container(border=True):
+            st.write(f"**{inc['id']}**: {inc['title']}")
+            st.caption(f"State: {inc['state']} | Severity: {inc['severity']}")
+else:
+    st.info("No critical incidents in last 24 hours")
+
+st.header("Unassigned")
+unassigned = get_unassigned(incidents)
+st.write(f"Total: {len(unassigned)}")
+
+if unassigned:
+    for inc in unassigned:
+        with st.container(border=True):
+            st.write(f"**{inc['id']}**: {inc['title']}")
+            st.caption(f"Severity: {inc['severity']}")
+
+st.header("Incidents by Day (Last 7 days)")
+by_day = get_incidents_by_day(incidents, 7)
+for day, count in sorted(by_day.items()):
+    st.write(f"{day}: {count} incidents")
+
+st.caption("*Manager view is read-only*")
+
+st.page_link("main.py", label="Back to list")

--- a/frontend/app/pages/manager_dashboard.py
+++ b/frontend/app/pages/manager_dashboard.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
-
 import streamlit as st
 
 from data import (
@@ -36,6 +34,7 @@ auto_refresh = st.checkbox("Auto-refresh (30s)", value=False)
 if auto_refresh:
     import time
     time.sleep(30)
+    st.rerun()
 
 st.header("Metrics")
 

--- a/frontend/app/pages/manager_dashboard.py
+++ b/frontend/app/pages/manager_dashboard.py
@@ -29,12 +29,26 @@ if not is_manager:
     st.page_link("main.py", label="Back to list")
     st.stop()
 
-auto_refresh = st.checkbox("Auto-refresh (30s)", value=False)
+
+def render_auto_refresh(interval_seconds: int = 30):
+    st.markdown(
+        f"""
+        <meta http-equiv="refresh" content="{interval_seconds}">
+        <script>
+            setTimeout(function(){{
+                window.location.reload();
+            }}, {interval_seconds * 1000});
+        </script>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+auto_refresh = st.checkbox("Auto-refresh (30s)", value=False, key="mgr_refresh")
 
 if auto_refresh:
-    import time
-    time.sleep(30)
-    st.rerun()
+    render_auto_refresh(30)
+
 
 st.header("Metrics")
 
@@ -52,8 +66,9 @@ with col4:
     st.metric("Low", severity_counts.get("low", 0))
 
 st.header("State Distribution")
-state_cols = st.columns(len(STATES))
-for idx, state in enumerate(STATES):
+state_cols = st.columns(len(st.session_state.get("states", ["open", "triaged", "assigned", "in_progress", "resolved", "closed"])))
+state_list = ["open", "triaged", "assigned", "in_progress", "resolved", "closed"]
+for idx, state in enumerate(state_list):
     with state_cols[idx]:
         st.metric(state.title().replace("_", " "), state_counts.get(state, 0))
 


### PR DESCRIPTION
## Summary
Closes #16

## Changes

### Manager Dashboard
- Severity counts (critical, high, medium, low)
- State distribution metrics
- Critical incidents recent (24h)
- Unassigned incidents list
- Incidents by day (last 7 days)
- Read-only view
- Auto-refresh checkbox (30s)

### Admin Dashboard  
- All Manager metrics
- Reassign incidents tab (can assign unassigned to users)
- Manage users tab (Coming Soon placeholder)
- Audit log with filters (by actor, by type)
- Access restricted to Admin role

### Navigation
- Dashboard link in main page (Manager/Admin only)
- Admin Panel link (Admin only)

### Role-based Access
- Manager: read-only dashboard
- Admin: full dashboard with reassign and audit log